### PR TITLE
fix: if prscd can not connect to zipper when creating, do not cache it

### DIFF
--- a/chirp/node.go
+++ b/chirp/node.go
@@ -124,6 +124,7 @@ func (n *node) ConnectToYoMo(credential string) error {
 		os.Getenv("YOMO_ZIPPER"),
 		yomo.WithCredential(credential),
 		yomo.WithTracerProvider(tp),
+		yomo.WithSourceReConnect(),
 	)
 
 	// rcvr is receiver to receive data from other prscd nodes by YoMo
@@ -132,6 +133,7 @@ func (n *node) ConnectToYoMo(credential string) error {
 		os.Getenv("YOMO_ZIPPER"),
 		yomo.WithSfnCredential(credential),
 		yomo.WithSfnTracerProvider(tp),
+		yomo.WithSfnReConnect(),
 	)
 
 	sndr.SetErrorHandler(func(err error) {

--- a/chirp/node.go
+++ b/chirp/node.go
@@ -37,7 +37,14 @@ func GetOrCreateRealm(appID string, credential string) (realm *node) {
 	if !ok {
 		log.Debug("create realm: %s", appID)
 		// connect to yomo zipper when created
-		res.(*node).ConnectToYoMo(credential)
+		err := res.(*node).ConnectToYoMo(credential)
+		// if can not connect to yomo zipper, remove this realm
+		if err != nil {
+			allRealms.Delete(appID)
+			// Consider return nil and close connection. But currently, I am trying to let client connected to this node, next time, it will try to connect to yomo zipper again, this will fix the network problem between prscd and yomo zipper.
+			// log.Error("connect to yomo zipper error: %+v", err)
+			// return nil
+		}
 	}
 
 	return res.(*node)

--- a/websocket/main.go
+++ b/websocket/main.go
@@ -148,6 +148,12 @@ func ListenAndServe(addr string, config *tls.Config) {
 		// now, the authorization is done, we can create realm instance by appID
 		node := chirp.GetOrCreateRealm(appID, credential)
 
+		// if can not connect to yomo zipper, close connection
+		if node == nil {
+			conn.Close()
+			return
+		}
+
 		// create peer instance after Websocket handshake
 		pconn := chirp.NewWebSocketConnection(conn)
 		peer := node.AddPeer(pconn, cuid)

--- a/webtransport/main.go
+++ b/webtransport/main.go
@@ -132,6 +132,10 @@ func handleConnection(sess quic.Connection) {
 	pconn := chirp.NewWebTransportConnection(sess)
 	// now, the authorization is done, we can create realm instance by appID
 	node := chirp.GetOrCreateRealm(appID, credential)
+	if node == nil {
+		closeReason = "can not connect to yomo zipper"
+		return
+	}
 
 	peer := node.AddPeer(pconn, userID)
 	log.Info("[%s-%s] Upgrade done!", peer.Sid, peer.Cid)


### PR DESCRIPTION
This is not the best solution, but makes service way better, at least prscd will try to reconnect zipper next time.