### PR TITLE
feat(psig): add serializer

### DIFF
--- a/.env
+++ b/.env
@@ -16,7 +16,7 @@ YOMO_ZIPPER=127.0.0.1:9000
 YOMO_SNDR_NAME=prscd-sender
 YOMO_RCVR_NAME=prscd-receiver
 #OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318
-YOMO_LOG_LEVEL=warn
+#YOMO_LOG_LEVEL=warn
 
 # Server TLS
 CERT_FILE=./lo.yomo.dev.cert

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ dev:
 
 .PHONY: test
 test:
-	MESH_ID=test go test ./...
+	# MESH_ID=test go test ./...
+	go test github.com/pilarjs/prscd/psig
 
 .PHONY: bench
 bench:

--- a/chirp/node.go
+++ b/chirp/node.go
@@ -158,10 +158,10 @@ func (n *node) ConnectToYoMo(credential string) error {
 		}
 		log.Debug("got sig", "sig", sig)
 
-		if sig.AppID != n.id {
-			log.Debug("ignore message from other app", "appID", sig.AppID)
-			return
-		}
+		// if sig.AppID != n.id {
+		// 	log.Debug("ignore message from other app", "appID", sig.AppID)
+		// 	return
+		// }
 
 		channel := n.FindChannel(sig.Channel)
 		if channel != nil {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/quic-go/quic-go v0.40.1
 	github.com/stretchr/testify v1.8.4
 	github.com/vmihailenco/msgpack/v5 v5.4.1
-	github.com/yomorun/yomo v1.17.3
+	github.com/yomorun/yomo v1.17.5
 	golang.org/x/sys v0.16.0
 )
 
@@ -30,6 +30,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.13.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/quic-go/qtls-go1-20 v0.4.1 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/yomorun/y3 v1.0.5 // indirect
 	go.opentelemetry.io/otel v1.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/quic-go/qtls-go1-20 v0.4.1 h1:D33340mCNDAIKBqXuAvexTNMUByrYmFYVfKfDN5
 github.com/quic-go/qtls-go1-20 v0.4.1/go.mod h1:X9Nh97ZL80Z+bX/gUXMbipO6OxdiDi58b/fMC9mAL+k=
 github.com/quic-go/quic-go v0.40.1 h1:X3AGzUNFs0jVuO3esAGnTfvdgvL4fq655WaOi1snv1Q=
 github.com/quic-go/quic-go v0.40.1/go.mod h1:PeN7kuVJ4xZbxSv/4OX6S1USOX8MJvydwpTx31vx60c=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
@@ -153,8 +155,8 @@ github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAh
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/yomorun/y3 v1.0.5 h1:1qoZrDX+47hgU2pVJgoCEpeeXEOqml/do5oHjF9Wef4=
 github.com/yomorun/y3 v1.0.5/go.mod h1:+zwvZrKHe8D3fTMXNTsUsZXuI+kYxv3LRA2fSJEoWbo=
-github.com/yomorun/yomo v1.17.3 h1:CGSvRHv0A5bpXo8L4qinAQg2HP3xsYTHXu7H35RDS9w=
-github.com/yomorun/yomo v1.17.3/go.mod h1:3sBqTh9fa/n2GSPVFupRLadcWVXaID4hvUv3QYcOKNA=
+github.com/yomorun/yomo v1.17.5 h1:wBhnQGy+8EO05bSqmyQWeLbE1YvhUGuqRTheLQOl3iw=
+github.com/yomorun/yomo v1.17.5/go.mod h1:lsSEdpNzQMGLV/JuzS1BCoO8PYqdg+7e8nTuWC91qzM=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
 go.opentelemetry.io/otel v1.21.0 h1:hzLeKBZEL7Okw2mGzZ0cc4k/A7Fta0uoPgaJCr8fsFc=
 go.opentelemetry.io/otel v1.21.0/go.mod h1:QZzNPQPm1zLX4gZK4cMi+71eaorMSGT3A4znnUvNNEo=

--- a/psig/serializer.go
+++ b/psig/serializer.go
@@ -17,7 +17,7 @@ func marshal(tag uint32, sig *Signalling) (uint32, []byte, error) {
 	return tag, buf, nil
 }
 
-// MarshalControlSig marshals the data signal with the given channel and payload.
+// MarshalDataSig marshals the data signal with the given channel and payload.
 func MarshalDataSig(channel string, payload interface{}, cid string) (uint32, []byte, error) {
 	payloadBuf, err := msgpack.Marshal(payload)
 	if err != nil {

--- a/psig/serializer.go
+++ b/psig/serializer.go
@@ -1,6 +1,7 @@
 package psig
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/vmihailenco/msgpack/v5"
@@ -19,6 +20,9 @@ func marshal(tag uint32, sig *Signalling) (uint32, []byte, error) {
 
 // MarshalDataSig marshals the data signal with the given channel and payload.
 func MarshalDataSig(channel string, payload any, cid string) (uint32, []byte, error) {
+	if channel == "" {
+		return 0, nil, fmt.Errorf("channel is required")
+	}
 	payloadBuf, err := msgpack.Marshal(payload)
 	if err != nil {
 		slog.Error("MarshalDataSig", "err", err)

--- a/psig/serializer.go
+++ b/psig/serializer.go
@@ -1,0 +1,36 @@
+package psig
+
+import (
+	"log/slog"
+
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+func marshal(tag uint32, sig *Signalling) (uint32, []byte, error) {
+	// encode sig with msgpack v5
+	buf, err := msgpack.Marshal(sig)
+	if err != nil {
+		slog.Error("marshal", "err", err)
+		return 0, nil, err
+	}
+
+	return tag, buf, nil
+}
+
+// MarshalControlSig marshals the data signal with the given channel and payload.
+func MarshalDataSig(channel string, payload interface{}, cid string) (uint32, []byte, error) {
+	payloadBuf, err := msgpack.Marshal(payload)
+	if err != nil {
+		slog.Error("MarshalDataSig", "err", err)
+		return 0, nil, err
+	}
+
+	sig := &Signalling{
+		Type:    SigData,
+		Channel: channel,
+		Payload: payloadBuf,
+		Cid:     cid,
+	}
+
+	return marshal(0x21, sig)
+}

--- a/psig/serializer.go
+++ b/psig/serializer.go
@@ -18,7 +18,7 @@ func marshal(tag uint32, sig *Signalling) (uint32, []byte, error) {
 }
 
 // MarshalDataSig marshals the data signal with the given channel and payload.
-func MarshalDataSig(channel string, payload interface{}, cid string) (uint32, []byte, error) {
+func MarshalDataSig(channel string, payload any, cid string) (uint32, []byte, error) {
 	payloadBuf, err := msgpack.Marshal(payload)
 	if err != nil {
 		slog.Error("MarshalDataSig", "err", err)

--- a/psig/serializer_test.go
+++ b/psig/serializer_test.go
@@ -45,6 +45,6 @@ func TestMarshalDataSigWithoutChannel(t *testing.T) {
 
 	expectedTag, expectedBuf, err := MarshalDataSig(channel, payload, cid)
 	assert.EqualValues(t, 0, expectedTag)
-	assert.EqualValues(t, nil, expectedBuf)
+	assert.Nil(t, expectedBuf)
 	assert.EqualError(t, err, "channel is required")
 }

--- a/psig/serializer_test.go
+++ b/psig/serializer_test.go
@@ -1,0 +1,50 @@
+package psig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+func TestMarshalDataSig(t *testing.T) {
+	channel := "testChannel"
+	payload := "testPayload"
+	cid := "testCid"
+
+	expectedTag, expectedBuf, err := MarshalDataSig(channel, payload, cid)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	payloadBuf, err := msgpack.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	sig := &Signalling{
+		Type:    SigData,
+		Channel: channel,
+		Payload: payloadBuf,
+		Cid:     cid,
+	}
+
+	tag, buf, err := marshal(0x21, sig)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	assert.Equal(t, tag, expectedTag)
+	assert.Equal(t, buf, expectedBuf)
+}
+
+func TestMarshalDataSigWithoutChannel(t *testing.T) {
+	channel := ""
+	payload := "testPayload"
+	cid := "testCid"
+
+	expectedTag, expectedBuf, err := MarshalDataSig(channel, payload, cid)
+	assert.EqualValues(t, 0, expectedTag)
+	assert.EqualValues(t, nil, expectedBuf)
+	assert.EqualError(t, err, "channel is required")
+}

--- a/websocket.html
+++ b/websocket.html
@@ -42,7 +42,7 @@
       if (resp.pl) {
         resp.pl = MessagePack.decode(resp.pl)
       }
-      console.info("\t>RCV")
+      console.info("\t>RCV", resp)
 
       // handle logic
       handleSignalling(socket, resp)
@@ -114,7 +114,7 @@
 
       // Data plane
       if (sig.t == "data") {
-        console.log(" * DATA", sig.pl)
+        console.log(" * DATA", sig.pl, "from", sig.p)
       }
     }
 


### PR DESCRIPTION
`psig.MarshalDataSig()` broadcast `payload` for `channel` as `cid`.

```go
import (
	"log/slog"
	"os"
	"time"

	psig "github.com/pilarjs/prscd/psig"
	"github.com/yomorun/yomo"
)

func main() {
	s := yomo.NewSource(
		"emitter",
		"localhost:9000",
	)
	defer s.Close()

	if err := s.Connect(); err != nil {
		slog.Error("[sfn] connect", "err", err)
		os.Exit(1)
	}

	// payload := strconv.FormatInt(time.Now().Unix(), 10)
	payload := time.Now().Unix()
	channel := "room-1"
	cid := "bot"

	// encode sig with msgpack v5
	tag, buf, err := psig.MarshalDataSig(channel, payload, cid)
	if err != nil {
		slog.Error("[emitter] msgpack.Marshal", "err", err)
	}

	// Create a ticker that fires every 2 seconds
	ticker := time.NewTicker(2 * time.Second)
	defer ticker.Stop()

	go func() {
		for range ticker.C {
			if err := s.Write(tag, buf); err != nil {
				slog.Error("[emitter] write", "err", err)
			} else {
				slog.Info("[emitter] write", "data", string(buf))
			}
		}
	}()

	select {}
}
```